### PR TITLE
Rws/s905x4

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -154,21 +154,14 @@ struct Cli {
 fn main() {
     let cmd = Cli::parse().cmd;
     let reboot = Cli::parse().reboot;
-    println!("Searching for Amlogic USB devices...");
-    let dev = rusb::devices()
-        .unwrap()
-        .iter()
-        .find(|dev| {
-            let des = dev.device_descriptor().unwrap();
-            let vid = des.vendor_id();
-            let pid = des.product_id();
 
-            vid == USB_VID_AMLOGIC
-                && matches!(pid, USB_PID_GX_CHIP | USB_PID_AML_DNL | USB_PID_GADGET)
-        })
-        .expect("Cannot find Amlogic USB device");
-
-    let des = dev.device_descriptor().unwrap();
+    let (dev, des, mut handle) = match protocol_adnl::discover() {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Device not found: {}", e);
+            return;
+        }
+    };
     let vid = des.vendor_id();
     let pid = des.product_id();
 
@@ -191,7 +184,6 @@ fn main() {
     // TODO: Not sure if this is sensible, or whether to use different
     // timeouts per command...
     let timeout = Duration::from_millis(2500);
-    let handle = dev.open().expect("Error opening USB device {e:?}");
 
     if let Ok(p) = handle.read_product_string_ascii(&des) {
         println!("Product string: {p}");
@@ -319,8 +311,7 @@ fn main() {
                 _ => protocol_adnl::OemWriteType::File(wic_p.to_str().unwrap()),
             };
 
-            let dev = protocol_adnl::do_flash(&handle).expect("Failed to flash");
-            let handle = dev.open().expect("Failed to open usb device");
+            protocol_adnl::do_flash(&mut handle).expect("Failed to flash");
             protocol_adnl::check_in_mode(&handle, protocol_adnl::BootMode::Tpl)
                 .expect("Not in correct mode for flash");
             protocol_adnl::oem_mwrite(&handle, 0, input);
@@ -350,9 +341,8 @@ fn main() {
         }
 
         Command::EraseMMC {} => {
-            let dev = protocol_adnl::erase_emmc(&handle).expect("Failed to invalidate mbr");
+            protocol_adnl::erase_emmc(&mut handle).expect("Failed to invalidate mbr");
             if reboot {
-                let handle = dev.open().expect("Failed to open usb device");
                 protocol_adnl::device_reboot(&handle);
             }
         }
@@ -369,8 +359,7 @@ fn main() {
                 _ => protocol_adnl::OemWriteType::File(wic_p.to_str().unwrap()),
             };
 
-            let dev = protocol_adnl::erase_emmc(&handle).expect("Failed to invalidate mbr");
-            let handle = dev.open().expect("Failed to open usb device");
+            protocol_adnl::erase_emmc(&mut handle).expect("Failed to invalidate mbr");
             protocol_adnl::check_in_mode(&handle, protocol_adnl::BootMode::Tpl)
                 .expect("Not in correct mode for flash-adnl");
             protocol_adnl::oem_mwrite(&handle, 0, input);

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ enum Command {
     /// put in downloader mode
     #[clap(verbatim_doc_comment)]
     Flash {
-        #[arg(short, long, index = 1, default_value = "")]
+        #[arg(index = 1, default_value = "")]
         wic: String,
     },
 
@@ -120,7 +120,7 @@ enum Command {
     /// put in adnl mode
     #[clap(verbatim_doc_comment)]
     FlashAdnl {
-        #[arg(short, long, index = 1, default_value = "")]
+        #[arg(index = 1, default_value = "")]
         wic: String,
     },
 
@@ -132,7 +132,7 @@ enum Command {
     #[clap(verbatim_doc_comment)]
     /// Erase enough emmc to fully reflash device
     DoItAll {
-        #[arg(short, long, index = 1, default_value = "")]
+        #[arg(index = 1, default_value = "")]
         wic: String,
     },
 }

--- a/src/protocol_adnl.rs
+++ b/src/protocol_adnl.rs
@@ -11,7 +11,7 @@ use std::{
 
 use bzip2::bufread::MultiBzDecoder;
 use regex::Regex;
-use rusb::{Device, GlobalContext};
+use rusb::{Device, DeviceDescriptor, DeviceHandle, GlobalContext};
 
 use crate::{protocol::Handle, USB_VID_AMLOGIC};
 
@@ -399,8 +399,9 @@ fn do_write_blk_cmd<'a>(h: &Handle, cmd: impl Into<BulkCommand<'a>>) -> Result<u
     })
 }
 
-pub fn do_bootloader_flash(h: &Handle) -> Result<Device<GlobalContext>, String> {
+pub fn do_bootloader_flash(h: &mut Handle) -> Result<(), String> {
     let data = UBOOT_USB_BIN_SIGNED;
+    let prev_addr = h.device().address();
 
     //// bl1_boot -f uboot.bin.usb.signed
     check_in_mode(h, BootMode::Bl1).expect("Should be in BL1 mode");
@@ -539,13 +540,13 @@ pub fn do_bootloader_flash(h: &Handle) -> Result<Device<GlobalContext>, String> 
     }
 
     // the device will 'boot' and reconnect as a different USB device number
-    Ok(wait_for_device_reconnect().expect("Failed to find device after reconnect!"))
+    let (_dev, _des, handle) = rediscover(Some(prev_addr)).unwrap();
+    *h = handle; // update the handle
+    Ok(())
 }
 
-pub fn erase_emmc(h: &Handle) -> Result<Device<GlobalContext>, String> {
-    let dev = do_bootloader_flash(h).expect("Failed to flash bootloader(s)");
-    let handle = dev.open().expect("Failed to open usb device");
-    let h = &handle;
+pub fn erase_emmc(h: &mut Handle) -> Result<(), String> {
+    do_bootloader_flash(h).expect("Failed to flash bootloader(s)");
 
     // this will wipe the boot partitions
     do_write_blk_cmd(h, "oem disk_initial 1").unwrap();
@@ -586,14 +587,11 @@ pub fn erase_emmc(h: &Handle) -> Result<Device<GlobalContext>, String> {
     do_write_blk_cmd(h, buf.as_ref()).expect("Failed to write checksum");
     do_read_bulk(h).unwrap();
 
-    Ok(dev)
+    Ok(())
 }
 
-pub fn do_flash(h: &Handle) -> Result<Device<GlobalContext>, String> {
-    let dev = do_bootloader_flash(h).expect("Failed to flash bootloader(s)");
-    let handle = dev.open().expect("Failed to open usb device");
-    let h = &handle;
-
+pub fn do_flash(h: &mut Handle) -> Result<(), String> {
+    do_bootloader_flash(h).expect("Failed to flash bootloader(s)");
     let data = UBOOT_BIN_SIGNED;
 
     let dlsize = data.len() as u32;
@@ -618,19 +616,27 @@ pub fn do_flash(h: &Handle) -> Result<Device<GlobalContext>, String> {
     do_write_blk_cmd(h, buf.as_ref()).expect("Failed to write checksum");
     do_read_bulk(h).unwrap();
 
+    // get current device address before reboot, for usb rediscovering
+    let prev_addr = h.device().address();
+
     do_write_blk_cmd(h, "reboot").unwrap();
     do_read_bulk(h).unwrap();
 
-    Ok(wait_for_device_reconnect().expect("Failed to detect device"))
+    let (_dev, _des, handle) = rediscover(Some(prev_addr)).unwrap();
+    *h = handle; // update the handle
+    Ok(())
 }
 
-fn find_usb_device() -> Result<Device<GlobalContext>, String> {
+fn find_usb_device(exclude_address: Option<u8>) -> Result<Device<GlobalContext>, String> {
     if let Some(dev) = rusb::devices().unwrap().iter().find(|dev| {
         let des = dev.device_descriptor().unwrap();
         let vid = des.vendor_id();
         let pid = des.product_id();
 
-        vid == USB_VID_AMLOGIC && matches!(pid, crate::USB_PID_AML_DNL)
+        vid == USB_VID_AMLOGIC && matches!(pid, crate::USB_PID_AML_DNL) && match exclude_address {
+            None => true,
+            Some(addr) => addr != dev.address(),
+        }
     }) {
         Ok(dev)
     } else {
@@ -638,37 +644,77 @@ fn find_usb_device() -> Result<Device<GlobalContext>, String> {
     }
 }
 
-fn wait_for_device_reconnect() -> Result<Device<GlobalContext>, String> {
-    // wait for this device to leave
+fn rediscover(prev_address: Option<u8>) -> Result<(Device<GlobalContext>, DeviceDescriptor, DeviceHandle<GlobalContext>), String> {
+    // wait for the device to show
+    // if prev_address argument is valid, we use it for checking if the discovered device has a different address
     let max = Duration::from_secs(30);
+    let fallback_delay = Duration::from_secs(5); // the fallback is for Windows only
     let now = Instant::now();
-    let curr_dev = find_usb_device().expect("Failed to find adnl device");
-    println!("Searching for Amlogic USB devices...");
-    while now.elapsed() < max {
+
+    if prev_address.is_none() {
+        println!("Searching for Amlogic USB devices...");
+    }
+
+    let mut exclude_addr = prev_address;
+    let dev = loop {
+        let elapsed = now.elapsed();
+        if elapsed >= max {
+            return Err("Failed to find device".into());
+        } else if std::env::consts::OS == "windows" && now.elapsed() >= fallback_delay {
+            // On Windows, even if the device has transitioned into TPL, we still get the device
+            // with the same address, which seems a libusb's platform dependent behavior. To
+            // workaround this, we give rediscover a fallback_delay, after which we ignore the
+            // previous address and discover any device.
+            exclude_addr = None;
+        }
+
         let left = 30 - now.elapsed().as_secs();
-        print!("Remaing time: {:<3}s\r", left);
+        print!("Remaining time: {:<3}s\r", left);
         std::io::stdout().flush().ok();
-        if let Ok(dev) = find_usb_device() {
-            if curr_dev.address() == dev.address() {
-                std::thread::sleep(Duration::from_millis(100));
-                continue;
-            } else {
-                std::thread::sleep(Duration::from_millis(250));
-                let ds = dev.device_descriptor().expect("Failed to get descriptor");
-                let vid = ds.vendor_id();
-                let pid = ds.product_id();
-                println!(
-                    "\nFound {vid:04x}:{pid:04x} on bus {:03}, device {:03}",
-                    dev.bus_number(),
-                    dev.address(),
-                );
-                return Ok(dev);
-            }
+
+        if let Ok(dev) = find_usb_device(exclude_addr) {
+            break dev;
         } else {
             std::thread::sleep(Duration::from_millis(100));
         }
+    };
+
+    let des = dev.device_descriptor().expect("Failed to get descriptor");
+    let mut handle = dev.open().expect("Error opening USB device {e:?}");
+
+    // configure the endpoints
+    let nb_configs = des.num_configurations();
+    if nb_configs < 1 {
+        return Err("The device has no configuration".into());
     }
-    Err("Failed to find device".into())
+
+    let config_desc = dev.config_descriptor(0).unwrap();
+    handle.set_active_configuration(config_desc.number()).unwrap();
+
+    for interface in config_desc.interfaces() {
+        for interface_desc in interface.descriptors() {
+            let iface = interface_desc.interface_number();
+            // let has_kernel_driver = match handle.kernel_driver_active(iface) {
+            //     Ok(true) => {
+            //         handle.detach_kernel_driver(iface).ok();
+            //         true
+            //     }
+            //     _ => false,
+            // };
+
+            // println!(" - kernel driver? {}", has_kernel_driver);
+            handle.claim_interface(iface).unwrap();
+            handle.set_alternate_setting(iface, interface_desc.setting_number()).unwrap();
+        }
+    }
+
+    handle.reset().unwrap();
+
+    Ok((dev, des, handle))
+}
+
+pub fn discover() -> Result<(Device<GlobalContext>, DeviceDescriptor, DeviceHandle<GlobalContext>), String> {
+    rediscover(None)
 }
 
 pub fn device_reboot(h: &Handle) {

--- a/src/protocol_adnl.rs
+++ b/src/protocol_adnl.rs
@@ -633,10 +633,12 @@ fn find_usb_device(exclude_address: Option<u8>) -> Result<Device<GlobalContext>,
         let vid = des.vendor_id();
         let pid = des.product_id();
 
-        vid == USB_VID_AMLOGIC && matches!(pid, crate::USB_PID_AML_DNL) && match exclude_address {
-            None => true,
-            Some(addr) => addr != dev.address(),
-        }
+        vid == USB_VID_AMLOGIC
+            && matches!(pid, crate::USB_PID_AML_DNL)
+            && match exclude_address {
+                None => true,
+                Some(addr) => addr != dev.address(),
+            }
     }) {
         Ok(dev)
     } else {
@@ -644,7 +646,16 @@ fn find_usb_device(exclude_address: Option<u8>) -> Result<Device<GlobalContext>,
     }
 }
 
-fn rediscover(prev_address: Option<u8>) -> Result<(Device<GlobalContext>, DeviceDescriptor, DeviceHandle<GlobalContext>), String> {
+fn rediscover(
+    prev_address: Option<u8>,
+) -> Result<
+    (
+        Device<GlobalContext>,
+        DeviceDescriptor,
+        DeviceHandle<GlobalContext>,
+    ),
+    String,
+> {
     // wait for the device to show
     // if prev_address argument is valid, we use it for checking if the discovered device has a different address
     let max = Duration::from_secs(30);
@@ -689,7 +700,9 @@ fn rediscover(prev_address: Option<u8>) -> Result<(Device<GlobalContext>, Device
     }
 
     let config_desc = dev.config_descriptor(0).unwrap();
-    handle.set_active_configuration(config_desc.number()).unwrap();
+    handle
+        .set_active_configuration(config_desc.number())
+        .unwrap();
 
     for interface in config_desc.interfaces() {
         for interface_desc in interface.descriptors() {
@@ -704,7 +717,9 @@ fn rediscover(prev_address: Option<u8>) -> Result<(Device<GlobalContext>, Device
 
             // println!(" - kernel driver? {}", has_kernel_driver);
             handle.claim_interface(iface).unwrap();
-            handle.set_alternate_setting(iface, interface_desc.setting_number()).unwrap();
+            handle
+                .set_alternate_setting(iface, interface_desc.setting_number())
+                .unwrap();
         }
     }
 
@@ -713,7 +728,14 @@ fn rediscover(prev_address: Option<u8>) -> Result<(Device<GlobalContext>, Device
     Ok((dev, des, handle))
 }
 
-pub fn discover() -> Result<(Device<GlobalContext>, DeviceDescriptor, DeviceHandle<GlobalContext>), String> {
+pub fn discover() -> Result<
+    (
+        Device<GlobalContext>,
+        DeviceDescriptor,
+        DeviceHandle<GlobalContext>,
+    ),
+    String,
+> {
     rediscover(None)
 }
 


### PR DESCRIPTION
Support Linux, Mac Os and Windows

Tested on:
- Linux ubuntu 22.04, 23.10
- Windows 11
- Mac Os Sonoma 14.3.1, Apple M2 Pro

Notes:
- On Mac OS, the interface must be claimed before operating on it.
- On Windows, the device address doesn't change even the device enters into TPL mode.