### PR TITLE
fix: Implement "info" sub-command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -207,9 +207,7 @@ fn main() {
         }
         Command::Info => {
             println!("\n=======\n");
-            // protocol::info(&handle, timeout);
             protocol_adnl::devices(&handle);
-            // protocol_adnl::oem_mwrite(&handle);
             println!();
         }
         Command::ChipInfo => {

--- a/src/protocol_adnl.rs
+++ b/src/protocol_adnl.rs
@@ -321,8 +321,8 @@ pub fn oem_mread(h: &Handle, offset: u64, len: u64) {
 }
 
 pub fn devices(_h: &Handle) {
-    // check_in_mode(h, BootMode::Bl1).unwrap();
-    // check_in_mode(h, BootMode::Bl2).unwrap();
+    let mode = identify(_h);
+    println!("Boot mode: {:?}", mode);
 }
 
 fn do_read_bulk(h: &Handle) -> Result<Vec<u8>, String> {


### PR DESCRIPTION
"info" sub-command shows current bootloader mode, which is used by Bright Broad Programming Web UI (repo: edge-manufacturing-service, not pushed yet) to check if the Bright board is ready for programming.