### PR TITLE
feat: add docker build github action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.cargo/
+target/

--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   buildx:
     timeout-minutes: 45
-    runs-on: [self-hosted, "mgmt-automation-xlarge"]
+    runs-on: [self-hosted, mgmt-automation-xlarge]
     steps:
       # Get the repositery's code
       - name: Checkout

--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -1,0 +1,50 @@
+
+name: Docker Build
+env:
+  GITHUB_USERNAME: auto-brightai
+
+on:
+
+  pull_request:
+    branches: s905x4-support
+  push:
+    branches: [s905x4-support, rws/**]
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  buildx:
+    timeout-minutes: 45
+    runs-on: [self-hosted, "mgmt-automation-xlarge"]
+    steps:
+      # Get the repositery's code
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_ORG_ADMIN_REPO_ALL }}
+
+      # checkout the private repo containing the action to run
+      - name: Checkout GitHub Action Repo
+        uses: actions/checkout@v2
+        with:
+          repository: BrightDotAi/github-actions
+          ref: v2.4.0
+          token: ${{ secrets.PAT_ORG_ADMIN_REPO_ALL }} # stored in GitHub secrets
+          path: .github/common
+      - name: Configure Git credentials
+        uses: de-vri-es/setup-git-credentials@v2.0.8
+        with:
+          credentials: |
+            https://${{ env.GITHUB_USERNAME }}:${{ secrets.PAT_ORG_ADMIN_REPO_ALL }}@github.com/
+
+      - name: Docker Buildx Build
+        uses: ./.github/common/ci/buildx
+        with:
+          image_name: brightai/aml_boot
+          registry_username: ${{ secrets.BRIGHTAI_DOCKER_HUB_BOT_USER }}
+          registry_password: ${{ secrets.BRIGHTAI_DOCKER_HUB_BOT_PW }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            GITHUB_USERNAME=${{ env.GITHUB_USERNAME }}
+            GITHUB_PAT=${{ secrets.PAT_ORG_ADMIN_REPO_ALL }}

--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -39,7 +39,7 @@ jobs:
             https://${{ env.GITHUB_USERNAME }}:${{ secrets.PAT_ORG_ADMIN_REPO_ALL }}@github.com/
 
       - name: Docker Buildx Build
-        uses: ./.github/common/ci/buildx
+        uses: ./.github/actions/common/ci/buildx
         with:
           image_name: brightai/aml_boot
           registry_username: ${{ secrets.BRIGHTAI_DOCKER_HUB_BOT_USER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM  --platform=$BUILDPLATFORM brightai/cross-rust-musl:latest AS builder
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG GITHUB_USERNAME
+ARG GITHUB_PAT
+
+WORKDIR /aml_boot
+COPY . .
+
+# cargo build
+RUN . /setup_env.sh && \
+    cargo build --release --target=$TARGET && \
+    cp /aml_boot/target/$TARGET/release/aml_boot /aml_boot/target/release/aml_boot && \
+    $strip_app /aml_boot/target/release/aml_boot
+
+FROM alpine:3.19 AS runner
+WORKDIR /aml_boot
+COPY --from=builder /aml_boot/target/release/aml_boot /aml_boot/aml_boot
+ENV PATH="/aml_boot:$PATH"


### PR DESCRIPTION
This commit is pushed for adding docker build github action. If it works then other git repositories can copy aml_boot tool from brightai/aml_boot to their docker images. 

- Dockerfile is tested locally on my computer;
- The workflow file comes from edge-ble-proxy. When I pushed, I see a workflow queued but never run. I checked available runners and it reported "No self-hosted runners", _any Github organization level configuration is needed_?