### PR TITLE
fix: erase the backup gpt header when erasing emmc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "bzip2",
  "clap",
  "clap-num",
+ "lazy_static",
  "regex",
  "rusb",
 ]
@@ -163,6 +164,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ edition = "2021"
 bzip2 = "0.4"
 clap = { version = "4.4.6", features = ["derive"] }
 clap-num = "1.0.2"
+lazy_static = "1.5.0"
 regex = "1"
 rusb = "0.9"

--- a/src/protocol_adnl.rs
+++ b/src/protocol_adnl.rs
@@ -267,7 +267,8 @@ fn do_oem_mwrite(h: &Handle, offset: u64, input: OemWriteType) -> Result<(), Str
 fn oem_erase_backup_gpt_header(h: &Handle) -> Result<(), String> {
     let sector = [0u8; 512];
     // first we try to erase the backup gpt header at a very large offset, certainly it will fail, but from the error message we can get the capacity
-    let result = do_oem_mwrite(h, 1024 * 1024 * 1024 * 1024 - 512, OemWriteType::Raw(&sector));
+    const LARGE_OFFSET: u64 = 1024 * 1024 * 1024 * 1024 - 512;
+    let result = do_oem_mwrite(h, LARGE_OFFSET, OemWriteType::Raw(&sector));
 
     match result {
         Ok(_) => Err("Bug, it's impossible to erase the gpt header at this location".into()),

--- a/src/protocol_adnl.rs
+++ b/src/protocol_adnl.rs
@@ -105,7 +105,7 @@ fn aggregator_thread(rx: Receiver<Vec<u8>>, tx2: Sender<Vec<u8>>) {
     }
 }
 
-fn do_write_data(h: &Handle, offset: u64, data: OemWriteDataType, tx: mpsc::Sender<usize>) {
+fn do_write_data(h: &Handle, offset: u64, data: OemWriteDataType, tx: mpsc::Sender<usize>) -> Result<(), String>{
     let mut offset = offset;
 
     let (tx1, rx1) = mpsc::sync_channel::<Vec<u8>>(1);
@@ -124,7 +124,7 @@ fn do_write_data(h: &Handle, offset: u64, data: OemWriteDataType, tx: mpsc::Send
                     String::from(CmdAdnl::OemMwriteInit(1, offset, data.len() as u64)).as_bytes(),
                 )
                 .unwrap();
-                do_read_bulk(h).unwrap();
+                do_read_bulk(h).map_err(|e| format!("Failed to read bulk data: {:?}", e))?;
                 // write the data into the expected chunks size
                 for ch in data.chunks(0x20000) {
                     do_write_blk_cmd(h, String::from(CmdAdnl::OemMwriteRequest).as_bytes())
@@ -141,6 +141,7 @@ fn do_write_data(h: &Handle, offset: u64, data: OemWriteDataType, tx: mpsc::Send
     }
     drop(tx);
     t1.join().unwrap();
+    Ok(())
 }
 
 fn progress_thread(rx: Receiver<usize>) -> JoinHandle<()> {
@@ -163,14 +164,18 @@ fn progress_thread(rx: Receiver<usize>) -> JoinHandle<()> {
                     break;
                 }
             }
-            print!(
-                "\rWrote {:>10}, Elapsed {:>6.02} seconds",
-                total,
-                now.elapsed().as_millis() as f64 / 1000.0
-            );
+            if total > 0 {
+                print!(
+                    "\rWrote {:>10}, Elapsed {:>6.02} seconds",
+                    total,
+                    now.elapsed().as_millis() as f64 / 1000.0
+                );
+            }
             io::stdout().flush().ok();
         }
-        println!();
+        if total > 0 {
+            println!();
+        }
     })
 }
 
@@ -237,7 +242,7 @@ fn chunker_thread(mut data: OemWriteDataType, notify_tx: SyncSender<Vec<u8>>) {
     }
 }
 
-pub fn oem_mwrite(h: &Handle, offset: u64, input: OemWriteType) {
+fn do_oem_mwrite(h: &Handle, offset: u64, input: OemWriteType) -> Result<(), String> {
     use bzip2::bufread;
     let (tx, rx) = std::sync::mpsc::channel::<usize>();
     let progress = progress_thread(rx);
@@ -254,8 +259,33 @@ pub fn oem_mwrite(h: &Handle, offset: u64, input: OemWriteType) {
         OemWriteType::Raw(data) => OemWriteDataType::Buff(data.to_owned()),
     };
 
-    do_write_data(h, offset, data, tx);
+    do_write_data(h, offset, data, tx)?;
     progress.join().expect("Failed to 'join' progress handle");
+    Ok(())
+}
+
+fn oem_erase_backup_gpt_header(h: &Handle) -> Result<(), String> {
+    let sector = [0u8; 512];
+    // first we try to erase the backup gpt header at a very large offset, certainly it will fail, but from the error message we can get the capacity
+    let result = do_oem_mwrite(h, 1024 * 1024 * 1024 * 1024 - 512, OemWriteType::Raw(&sector));
+
+    match result {
+        Ok(_) => Err("Bug, it's impossible to erase the gpt header at this location".into()),
+        Err(e) => {
+            let re = Regex::new(r"capacity < partStartOff \+ imgSize 0x:(?<capacity>[0-9a-f]+) ").unwrap();
+            if let Some(caps) = re.captures(&e) {
+                // now we have the capacity, we can calculate the correct offset to erase the backup gpt header
+                let capacity = u64::from_str_radix(&caps["capacity"], 16).unwrap();
+                do_oem_mwrite(h, capacity - 512, OemWriteType::Raw(&sector))
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+pub fn oem_mwrite(h: &Handle, offset: u64, input: OemWriteType) {
+   do_oem_mwrite(h, offset, input).expect("Failed to 'oem write'");
 }
 
 pub fn oem_mread(h: &Handle, offset: u64, len: u64) {
@@ -559,6 +589,10 @@ pub fn erase_emmc(h: &mut Handle) -> Result<(), String> {
 
     // for good measure, blow away the mbr too
     oem_mwrite(h, 0, OemWriteType::Raw(&data));
+
+    // erase the backup GPT header at the last sector of the storage.
+    // without doing this, U-Boot will be misled by the presence of the backup GPT header.
+    oem_erase_backup_gpt_header(h).unwrap();
 
     // reflash the bootloader we just erased to boot into adnl mode
     let data = UBOOT_BIN_SIGNED;


### PR DESCRIPTION
Ensure that the backup GPT header is erased during the eMMC erasure process. Devices accidentally with a valid backup GPT header may encounter issues where U-Boot misinterprets the presence of the header. They might boot successfully only once, but subsequent reboots will fail indefinitely.

>> We found that all new bright boards failed to boot again after the first boot, this commit fixes it.